### PR TITLE
Stop sending price change emails

### DIFF
--- a/apps/grolsch/management/commands/update_prices.py
+++ b/apps/grolsch/management/commands/update_prices.py
@@ -27,7 +27,6 @@ class Command(BaseCommand):
                 change.new_price = price
                 change.save()
 
-                change.mail()
             elif product.last_price == price:
                 product.last_discount_price = None
                 product.save()


### PR DESCRIPTION
Every day at 00:05 approximately 25 mails were sent with price changes. We don't want those anymore.