### PR TITLE
Remove broken allow_cidr middleware

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ Django>=5,<6
 django-sslserver-v2>=1, <2
 django-environ>=0.11
 sentry-sdk[django]>=2.0,<3.0
-django-allow-cidr>=0.7,<1.0
 
 mysqlclient>=2.2,<2.3
 requests>=2.31,<2.40

--- a/settings/environ.py
+++ b/settings/environ.py
@@ -44,23 +44,13 @@ PYDEV_DEBUGGER_IP     = None
 # Do not redirect to HTTPS, because the nginx proxy container only listens on HTTP
 SECURE_SSL_REDIRECT   = False
 
-# Add allow cidr middleware as first middleware
-MIDDLEWARE = ["allow_cidr.middleware.AllowCIDRMiddleware"] + MIDDLEWARE
-
 # Allowed hosts -- localhost and 127.0.0.1 are always allowed, the rest comes from an environment variable.
 ALLOWED_HOSTS = [
     "localhost", "127.0.0.1"
 ] + env.list("DJANGO_ALLOWED_HOSTS", default=[])
 
-# Allowed CIDR nets -- for kubernetes internal services
-ALLOWED_CIDR_NETS = ['172.30.0.0/16']
-ALLOWED_CIDR_NETS.extend(env.list("DJANGO_ALLOWED_CIDR_NETS", default=[]))
-
 # Add Kubernetes POD IP, if running in Kubernetes
 KUBE_POD_IP = env("THIS_POD_IP", default="")
-if KUBE_POD_IP:
-  ALLOWED_CIDR_NETS.append(KUBE_POD_IP)
-
 
 ADMINS = getaddresses([env("DJANGO_ADMINS", default="SBZ <www@sbz.utwente.nl>")])
 MANAGERS = ADMINS


### PR DESCRIPTION
Remove django_allow_cidr middleware, not necessary any more and breaks production.